### PR TITLE
git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+vendor/* linguist-vendored
+docs/* linguist-documentation


### PR DESCRIPTION
Introducing git-attributes to explicitly mark `vendor` and `docs` directories.

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>