### PR TITLE
feat(cmd): add support for gke auth provider

### DIFF
--- a/cmd/kubectl-trace/root.go
+++ b/cmd/kubectl-trace/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fntlnz/kubectl-trace/pkg/cmd"
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/fntlnz/kubectl-trace
 
 require (
+	cloud.google.com/go v0.34.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/docker/distribution v2.6.2+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20181124105010-0b7cb16dde4a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
+cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVkjK4=


### PR DESCRIPTION
This allows `kubectl-trace` to talk to GKE clusters where the kubeconfig was provided by `gcloud container clusters get-credentials`.