### PR TITLE
feat(tracejob): share pid namespace with host

### DIFF
--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -213,6 +213,7 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: commonMeta,
 				Spec: apiv1.PodSpec{
+					HostPID: true,
 					Volumes: []apiv1.Volume{
 						apiv1.Volume{
 							Name: "program",


### PR DESCRIPTION
At the current moment, using uprobes/uretprobes with kubectl trace is not possibile because the container containing bpftrace does not have any way to actually see what's going on in other processes since it does not see the root namespace.

This change will allow users to actually run those probes on their container processes by knowing the process id in the host, it's not super convenient but I think it's better to have something working now so that then we can focus on real support for pods as discussed in #3.

So, in a simple case, a user could do:


Get the actual pid and symbols you want to analyze whith a shell in the node:

```
ps -fe | grep caturday
root 10803 1 0 07:26 00:00:01 /caturday 
```

```
sudo objdump -t /proc/10803/exe | grep -i counterValue
main.counterValue
```

Send the actual uprobe with kubectl trace.

```
kubectl trace run -e 'uretprobe:/proc/10803/exe:"main.counterValue" { printf("%d\n", retval) }' 127.0.0.1 -a
```

I'm not sure I want this but I did this for the demo at kubecon so wanted to keep track.
Probably a better way for now would like to actually add some initial support for pods instead by adding a sidecar to them using the 1.13 `shareProcessNamespace` beta feature (see [here](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/)) and leverage the same mechanism however this would actually need something on the sidecar to atually resolve the process id inside that namespace so that the user doesn't have to go there take it.

TODO:
- [x] share host pid
- [ ] document usage

Signed-off-by: Lorenzo Fontana <lo@linux.com>